### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
ci.yml is set to run only on pushes:

    on: push

That works fine when everyone is pushing their branches to the same
repo, but on a public repo we will get pull requests from other’s repos
as well.

So also run CI on pull requests:

    on: [push, pull_request]