### PR TITLE
Add groupPages function

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,8 @@
         "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
         "ianmackenzie/elm-units": "2.3.0 <= v < 3.0.0",
-        "mdgriffith/elm-ui": "1.1.5 <= v < 2.0.0"
+        "mdgriffith/elm-ui": "1.1.5 <= v < 2.0.0",
+        "zwilias/elm-rosetree": "1.5.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "insurello/elm-ui-explorer",
     "summary": "Explore and interact with UI components and pages you've created",
     "license": "MIT",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "exposed-modules": [
         "UiExplorer"
     ],

--- a/example/elm.json
+++ b/example/elm.json
@@ -23,7 +23,8 @@
             "justinmimbs/time-extra": "1.1.0",
             "mdgriffith/elm-ui": "1.1.5",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3",
-            "ryannhg/date-format": "2.3.0"
+            "ryannhg/date-format": "2.3.0",
+            "zwilias/elm-rosetree": "1.5.0"
         },
         "indirect": {
             "elm/random": "1.0.0",

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -87,16 +87,24 @@ footer =
 
 pages =
     UiExplorer.firstPage newSignup newSignupPage
-        |> nextPageWithWidth newSignup newSignupPage 320
-        |> nextPageWithWidth newSignup newSignupPage 1000
-        |> UiExplorer.nextPage newLogin newLoginPage
-        |> nextPageWithWidth newLogin newLoginPage 320
-        |> nextPageWithWidth newLogin newLoginPage 1000
-        |> UiExplorer.nextPage footer (UiExplorer.static footerView)
-        |> nextPageWithWidth footer (UiExplorer.static footerView) 320
-        |> nextPageWithWidth footer (UiExplorer.static footerView) 1000
-        |> UiExplorer.nextPage "BankID" (UiExplorer.static UiExplorer.BankId.view)
-        |> nextPageWithWidth "BankID" (UiExplorer.static UiExplorer.BankId.view) 320
+        |> UiExplorer.groupPages "Signup and login"
+            (nextPageWithWidth newSignup newSignupPage 320
+                >> nextPageWithWidth newSignup newSignupPage 1000
+                >> UiExplorer.groupPages "Login"
+                    (nextPageWithWidth newLogin newLoginPage 320
+                        >> nextPageWithWidth newLogin newLoginPage 1000
+                        >> UiExplorer.nextPage newLogin newLoginPage
+                    )
+            )
+        |> UiExplorer.groupPages "Footer"
+            (UiExplorer.nextPage footer (UiExplorer.static footerView)
+                >> nextPageWithWidth footer (UiExplorer.static footerView) 320
+                >> nextPageWithWidth footer (UiExplorer.static footerView) 1000
+            )
+        |> UiExplorer.groupPages "BankID"
+            (UiExplorer.nextPage "BankID" (UiExplorer.static UiExplorer.BankId.view)
+                >> nextPageWithWidth "BankID" (UiExplorer.static UiExplorer.BankId.view) 320
+            )
         |> UiExplorer.nextPage "DesignSystem.Input" (UiExplorer.static (\_ _ -> DesignSystemInput.view))
 
 

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -101,10 +101,8 @@ pages =
                 >> nextPageWithWidth footer (UiExplorer.static footerView) 320
                 >> nextPageWithWidth footer (UiExplorer.static footerView) 1000
             )
-        |> UiExplorer.groupPages "BankID"
-            (UiExplorer.nextPage "BankID" (UiExplorer.static UiExplorer.BankId.view)
-                >> nextPageWithWidth "BankID" (UiExplorer.static UiExplorer.BankId.view) 320
-            )
+        |> UiExplorer.nextPage "BankID" (UiExplorer.static UiExplorer.BankId.view)
+        |> nextPageWithWidth "BankID" (UiExplorer.static UiExplorer.BankId.view) 320
         |> UiExplorer.nextPage "DesignSystem.Input" (UiExplorer.static (\_ _ -> DesignSystemInput.view))
 
 

--- a/src/UiExplorer.elm
+++ b/src/UiExplorer.elm
@@ -255,7 +255,7 @@ nextPage id config (PageBuilder previous) =
 
 Two things to note:
 
-  - Normally pages need unique names but with groups, it's okay to have two pages use the same name so long as they are in different groups.
+  - Normally pages need unique names, but with groups it's okay to have two pages use the same name so long as they are in different groups.
   - Due to [`firstPage`](#firstPage) having a different type signature from [`nextPage`](#nextPage), you can't place the first page in a group.
     If this is a problem, [create an issue on github](https://github.com/insurello/elm-ui-explorer/issues/new) explaining your use case.
 

--- a/src/UiExplorer.elm
+++ b/src/UiExplorer.elm
@@ -745,7 +745,7 @@ listNeighborsHelper list { previous, current, next } newList =
 
 pageGroupToString : List String -> String
 pageGroupToString =
-    List.intersperse "/" >> String.concat
+    uiUrl []
 
 
 isGroupExpanded : { a | expandedGroups : Set String } -> List String -> Bool

--- a/src/UiExplorer.elm
+++ b/src/UiExplorer.elm
@@ -826,11 +826,11 @@ buildTree items =
 
 
 mouseOverButtonColor buttonDepth =
-    mix (0.9 ^ toFloat buttonDepth) gray black
+    mix (0.92 ^ toFloat buttonDepth) gray black
 
 
 pageSelectedButtonColor buttonDepth =
-    mix (0.9 ^ toFloat buttonDepth) lightBlue black
+    mix (0.92 ^ toFloat buttonDepth) lightBlue black
 
 
 viewSidebarLinksHelper :
@@ -871,7 +871,7 @@ viewSidebarLinksHelper config model path trees =
                                         Element.Background.color <| Element.rgba 0 0 0 0
 
                                       else
-                                        Element.Background.color <| Element.rgba 0 0 0 0.1
+                                        Element.Background.color <| Element.rgba 0 0 0 0.08
                                     ]
                                     { onPress = ToggledExpandGroup newPath |> Just
                                     , label =
@@ -896,7 +896,7 @@ viewSidebarLinksHelper config model path trees =
                         in
                         if isGroupExpanded model newPath then
                             Element.column
-                                [ Element.width Element.fill, Element.Background.color <| Element.rgba 0 0 0 0.1 ]
+                                [ Element.width Element.fill, Element.Background.color <| Element.rgba 0 0 0 0.08 ]
                                 (groupButton True :: viewSidebarLinksHelper config model newPath children)
 
                         else


### PR DESCRIPTION
# Problem
We are starting to have a lot of pages. This makes the sidebar cluttered and means more convoluted names are needed to keep page names unique.

# Solution
Let pages be placed in groups which also act as namespaces.