### PR TITLE
Get page paths

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "insurello/elm-ui-explorer",
     "summary": "Explore and interact with UI components and pages you've created",
     "license": "MIT",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "exposed-modules": [
         "UiExplorer"
     ],

--- a/src/UiExplorer.elm
+++ b/src/UiExplorer.elm
@@ -1,6 +1,6 @@
 module UiExplorer exposing
     ( application, defaultConfig, ApplicationConfig, Model, Msg, PageMsg
-    , firstPage, nextPage, groupPages, static, Page, PageSize, PageBuilder
+    , firstPage, nextPage, groupPages, static, getPagePaths, Page, PageSize, PageBuilder
     )
 
 {-|
@@ -25,7 +25,7 @@ You can still use [`elm/html`](https://package.elm-lang.org/packages/elm/html/la
 A "page" is something you can select in the sidebar to display when the app is running.
 Pages can contain a single widget, tables showing every variation of your button components, or an entire login page. It's up to you!
 
-@docs firstPage, nextPage, groupPages, static, Page, PageSize, PageBuilder
+@docs firstPage, nextPage, groupPages, static, getPagePaths, Page, PageSize, PageBuilder
 
 -}
 
@@ -137,6 +137,26 @@ type PageBuilder model msg flags
         , ids : List { pageId : String, pageGroup : List String }
         , pageGroup : List String
         }
+
+
+{-| Get the relative paths to all the pages you've defined.
+
+    pages =
+        UiExplorer.firstPage "First page" (UiExplorer.static (\_ _ -> Element.none))
+            |> UiExplorer.nextPage "Second page" (UiExplorer.static (\_ _ -> Element.none))
+
+    paths =
+        -- [ "/First%20page", "/Second%page" ]
+        getPagePaths [] pages
+
+    pathWithSubdomain =
+        -- [ "/subdomain/First%20page", "/subdomain/Second%page" ]
+        getPagePaths [ "subdomain" ] pages
+
+-}
+getPagePaths : List String -> PageBuilder model msg flags -> List String
+getPagePaths relativeUrlPath (PageBuilder { ids }) =
+    List.map (\a -> (relativeUrlPath ++ a.pageGroup ++ [ a.pageId ]) |> List.map (Url.percentEncode >> (++) "/") |> String.concat) ids
 
 
 {-| A page that doesn't change or react to user input. It's just a view function.

--- a/src/UiExplorer.elm
+++ b/src/UiExplorer.elm
@@ -146,11 +146,11 @@ type PageBuilder model msg flags
             |> UiExplorer.nextPage "Second page" (UiExplorer.static (\_ _ -> Element.none))
 
     paths =
-        -- [ "/First%20page", "/Second%page" ]
+        -- [ "/First%20page", "/Second%20page" ]
         getPagePaths [] pages
 
     pathWithSubdomain =
-        -- [ "/subdomain/First%20page", "/subdomain/Second%page" ]
+        -- [ "/subdomain/First%20page", "/subdomain/Second%20page" ]
         getPagePaths [ "subdomain" ] pages
 
 -}

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,10 +1,41 @@
 module Tests exposing (..)
 
+import Element
 import Expect
-import Test
+import Test exposing (describe, test)
+import UiExplorer
+
+
+pages =
+    UiExplorer.firstPage "First page" (UiExplorer.static (\_ _ -> Element.none))
+        |> UiExplorer.groupPages "/nested/"
+            (UiExplorer.nextPage "nested_page" (UiExplorer.static (\_ _ -> Element.none))
+                >> UiExplorer.groupPages "DoubleNested"
+                    (UiExplorer.nextPage
+                        "DoubleNestedPage"
+                        (UiExplorer.static (\_ _ -> Element.none))
+                    )
+            )
 
 
 {-| Not a lot we can test really.
 -}
 tests =
-    Test.test "Dummy test" <| \_ -> Expect.pass
+    describe "UI explorer tests"
+        [ test "Get page paths" <|
+            \_ ->
+                UiExplorer.getPagePaths [] pages
+                    |> Expect.equal
+                        [ "/%2Fnested%2F/DoubleNested/DoubleNestedPage"
+                        , "/%2Fnested%2F/nested_page"
+                        , "/First%20page"
+                        ]
+        , test "Get page paths with relative path" <|
+            \_ ->
+                UiExplorer.getPagePaths [ "relative", "path" ] pages
+                    |> Expect.equal
+                        [ "/relative/path/%2Fnested%2F/DoubleNested/DoubleNestedPage"
+                        , "/relative/path/%2Fnested%2F/nested_page"
+                        , "/relative/path/First%20page"
+                        ]
+        ]


### PR DESCRIPTION
# Problem

We needed to know all of the page urls when doing visual regression testing.

# Solution

Add a function that returns that data 